### PR TITLE
Remove mocked meta data

### DIFF
--- a/OpenReferralApi/Services/ValidatorService.cs
+++ b/OpenReferralApi/Services/ValidatorService.cs
@@ -46,13 +46,7 @@ public class ValidatorService : IValidatorService
                 Profile = profile
             },
             TestSuites = new List<TestGroup>(),
-            Metadata = new List<MetaData>
-            {
-                new() {Label = "Service provider", Value = "Fooshire County Council"},
-                new() {Label = "Email", Value = "service@fooshire.gov"},
-                new() {Label = "Telephone", Value = "+44 123 456 7890"},
-                new() {Label = "Region", Value = "South West"}
-            }
+            Metadata = new List<MetaData>() // TODO Add meta data if available
         };
 
         foreach (var testGroup in testProfile.Value.TestGroups)


### PR DESCRIPTION
## Remove mocked meta data

### What's changed?

- Removed mocked meta data from the validator response

### Why?

The validator is no longer running on mocks and can now accept live services so should no longer return fixed mock data

### Next Steps

Add ability to retrieve meta data from the `GET /` API details endpoint for V3