### PR TITLE
Add user-agent to request headers

### DIFF
--- a/OpenReferralApi/Services/RequestService.cs
+++ b/OpenReferralApi/Services/RequestService.cs
@@ -12,6 +12,7 @@ public class RequestService : IRequestService
     public RequestService(HttpClient httpClient)
     {
         _httpClient = httpClient;
+        _httpClient.DefaultRequestHeaders.Add("User-Agent", "oruk");
     }
 
     public async Task<Result<JsonNode>> GetApiResponse(string url)


### PR DESCRIPTION
## Add user-agent to request headers

### What's changed?

- Add `user-agent: oruk` to request headers

### Why?

Good practice and to avoid issues with firewall rules that reject requests without a user-agent header