### PR TITLE
Dashboard service details updates

### DIFF
--- a/OpenReferralApi/Models/DashboardServiceDetails.cs
+++ b/OpenReferralApi/Models/DashboardServiceDetails.cs
@@ -7,6 +7,8 @@ public class DashboardServiceDetails
         Title = serviceData.Name;
         Publisher = serviceData.Publisher;
         ServiceUrl = serviceData.ServiceUrl;
+        if (float.Parse(serviceData.SchemaVersion.Value.ToString()) == 1.0f)
+            ServiceUrl.Url += "/services";
         IsValid = serviceData.StatusIsValid;
         if (int.TryParse(IsValid.Value.ToString(), out var isValid))
         {

--- a/OpenReferralApi/Models/DashboardServiceDetails.cs
+++ b/OpenReferralApi/Models/DashboardServiceDetails.cs
@@ -25,7 +25,8 @@ public class DashboardServiceDetails
                 {
                     serviceData.Developer,
                     serviceData.Comment,
-                    serviceData.Description
+                    serviceData.Description,
+                    serviceData.SchemaVersion
                 }
             }
         };


### PR DESCRIPTION
## Dashboard service details updates

### What's changed?

- Appened `/services` on to V1 services data feed urls
- Add the schema version to the metadata

### Why?

Make the page more user friendly, prevent people from following the datafeed links to a 404