### PR TITLE
Stop appending '/services' for V1 service urls

### DIFF
--- a/OpenReferralApi/Models/DashboardServiceDetails.cs
+++ b/OpenReferralApi/Models/DashboardServiceDetails.cs
@@ -7,8 +7,6 @@ public class DashboardServiceDetails
         Title = serviceData.Name;
         Publisher = serviceData.Publisher;
         ServiceUrl = serviceData.ServiceUrl;
-        if (float.Parse(serviceData.SchemaVersion.Value.ToString()) == 1.0f)
-            ServiceUrl.Url += "/services";
         IsValid = serviceData.StatusIsValid;
         if (int.TryParse(IsValid.Value.ToString(), out var isValid))
         {


### PR DESCRIPTION
## Stop appending '/services' for V1 service urls

### What's changed?

- Remove change from #39 to add '/services' to V1 service urls

### Why?

Rather than adding this change for one response going to make a data change for V1 urls that will be reflected across the board