### PR TITLE
Use service value rather than url for V1

### DIFF
--- a/OpenReferralApi/Models/DashboardValidationResponse.cs
+++ b/OpenReferralApi/Models/DashboardValidationResponse.cs
@@ -7,5 +7,6 @@ public class DashboardValidationResponse
     public bool ServiceAvailable { get; set; }
     public bool TestsPassed { get; set; }
     public string Version { get; set; }
+    public string Service { get; set; }
     public string? Message { get; set; }
 }

--- a/OpenReferralApi/Services/DashboardService.cs
+++ b/OpenReferralApi/Services/DashboardService.cs
@@ -71,12 +71,16 @@ public class DashboardService : IDashboardService
             {
                 Id = service.Id!,
                 Name = service.Name.Value!.ToString()!,
-                Version = service.SchemaVersion!.Value!.ToString()!
+                Version = service.SchemaVersion!.Value!.ToString()!,
+                Service = service.ServiceUrl!.Url!
             };
             
             try
             {
-                var serviceAvailable = await IsServiceAvailable(service.ServiceUrl!.Url);
+                if (testResult.Version == "1.0")
+                    testResult.Service = service.ServiceUrl.Value.ToString();
+                
+                var serviceAvailable = await IsServiceAvailable(testResult.Service);
                 if (serviceAvailable.IsFailed)
                 {
                     testResult.TestsPassed = false;


### PR DESCRIPTION
## *ADD_A_TITLE*

### What's changed?

- Use service value rather than url for V1

### Why?

To handle data change for V1 services