### PR TITLE
Add workflow_dispatch trigger for build workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -8,6 +8,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
## Add workflow_dispatch trigger for build workflow

### What's changed?

- Added a `workflow_dispatch` trigger for the build workflow

### Why?

- So the build workflow can be run on demand in the same way as the deploy workflow