### PR TITLE
API issue feedback

### DIFF
--- a/OpenReferralApi/Services/RequestService.cs
+++ b/OpenReferralApi/Services/RequestService.cs
@@ -47,7 +47,7 @@ public class RequestService : IRequestService
         catch (Exception e)
         {
             Console.WriteLine(e);
-            return Result.Fail(e.Message);
+            return Result.Fail("Encountered an error whilst trying to make the API request");
         }
     }
 }

--- a/OpenReferralApi/Services/RequestService.cs
+++ b/OpenReferralApi/Services/RequestService.cs
@@ -16,6 +16,7 @@ public class RequestService : IRequestService
         _httpClient = httpClient;
         _cache = cache;
         _cacheOptions = new MemoryCacheEntryOptions().SetAbsoluteExpiration(TimeSpan.FromSeconds(90));
+        _httpClient.Timeout = TimeSpan.FromSeconds(30);
         _httpClient.DefaultRequestHeaders.Add("User-Agent", "oruk");
     }
 
@@ -25,10 +26,10 @@ public class RequestService : IRequestService
         {
             if (_cache.TryGetValue(url, out JsonNode? cacheData))
                 return cacheData!;
-            
+
             var result = await _httpClient.GetAsync(url);
             var resultString = await result.Content.ReadAsStringAsync();
-            
+
             if (!result.IsSuccessStatusCode)
                 return Result.Fail(new Error(result.ReasonPhrase, new Error(resultString)));
 

--- a/OpenReferralApi/Services/RequestService.cs
+++ b/OpenReferralApi/Services/RequestService.cs
@@ -39,6 +39,11 @@ public class RequestService : IRequestService
 
             return responseData!;
         }
+        catch (TaskCanceledException e)
+        {
+            Console.WriteLine(e);
+            return Result.Fail($"Request timed out after {_httpClient.Timeout.Seconds} seconds");
+        }
         catch (Exception e)
         {
             Console.WriteLine(e);

--- a/OpenReferralApi/Services/RequestService.cs
+++ b/OpenReferralApi/Services/RequestService.cs
@@ -15,7 +15,7 @@ public class RequestService : IRequestService
     {
         _httpClient = httpClient;
         _cache = cache;
-        _cacheOptions = new MemoryCacheEntryOptions().SetAbsoluteExpiration(TimeSpan.FromSeconds(90));
+        _cacheOptions = new MemoryCacheEntryOptions().SetAbsoluteExpiration(TimeSpan.FromSeconds(20));
         _httpClient.Timeout = TimeSpan.FromSeconds(30);
         _httpClient.DefaultRequestHeaders.Add("User-Agent", "oruk");
     }


### PR DESCRIPTION
## API issue feedback

### What's changed?

- Reduce request timeouts to 30 seconds
- Reduce memory cache to 20 seconds
- Catch timeout errors & return a descriptive message
- Return a generic message for other API issues

### Why?

- Saw some timeouts whilst users were testing with the validator
    - Want to return a helpful & specific message in that case
- Return a generic message for API issues rather than exposing the raw exception message 
- Reducing memory cache as it should be as short as it can be for this scenario