### PR TITLE
log detailed exceptions

### DIFF
--- a/OpenReferralApi/Models/TestProfile.cs
+++ b/OpenReferralApi/Models/TestProfile.cs
@@ -2,6 +2,6 @@ namespace OpenReferralApi.Models;
 
 public class TestProfile
 {
-    public string Profile { get; set; } = null!;
-    public List<TestCaseGroup> TestGroups { get; set; } = null!;
+    public required string Profile { get; set; }
+    public required List<TestCaseGroup> TestGroups { get; set; }
 }

--- a/OpenReferralApi/Services/Interfaces/ITestProfileService.cs
+++ b/OpenReferralApi/Services/Interfaces/ITestProfileService.cs
@@ -1,10 +1,9 @@
-using FluentResults;
 using OpenReferralApi.Models;
 
 namespace OpenReferralApi.Services.Interfaces;
 
 public interface ITestProfileService
 {
-    public Task<(string, string)> SelectTestSchema(string serviceUrl, string? profileInput);
-    public Task<Result<TestProfile>> ReadTestProfileFromFile(string testSchema);
+    Task<(string, string)> SelectTestSchema(string serviceUrl, string? profileInput);
+    Task<TestProfile?> ReadTestProfileFromFile(string testSchema);
 }


### PR DESCRIPTION
## Refactoring error messages

### Some changes to consolidate exception messages being logged.

Previously two log entries could be made for an exception. As the validation tasks are now run concurrently, the log messages can appear out of order.  I have consolidated some into a single log entry to avoid this.

I have also refactored to return a more accurate reason for failure in some cases.
